### PR TITLE
[Fix]  : Buffer explicitly require typo

### DIFF
--- a/browser/index.js
+++ b/browser/index.js
@@ -1,4 +1,4 @@
-var Buffer = require('buffer').Buffer
+var Buffer = require('buffer/').Buffer
 var createHash = require('create-hash')
 var stream = require('readable-stream')
 var inherits = require('inherits')


### PR DESCRIPTION
Hi All,  first I just want to thanks for the amazing job!!

I found a bug related to this [commit](https://github.com/crypto-browserify/browserify-sign/commit/92b2b838ec86e61d6840b6adc7c0785835bcd6ee)  that breaks the use of `crypto` in the browser.

![image](https://user-images.githubusercontent.com/363911/81216597-8d403480-8fb1-11ea-8a5a-f66c76bb39a6.png)

Related to this code

```
var algorithms = require('./algorithms.json')
Object.keys(algorithms).forEach(function (key) {
  algorithms[key].id = Buffer.from(algorithms[key].id, 'hex')
  algorithms[key.toLowerCase()] = algorithms[key]
})
```

As this `Note` ( https://www.npmjs.com/package/buffer#usage )

```
To require this module explicitly, use require('buffer/') which tells the node.js module lookup algorithm (also used by browserify) to use the npm module named buffer instead of the node.js core module named buffer!
```

I think the line should be

```
var Buffer = require('buffer/').Buffer  // note: the trailing slash is important!
```

( I try this fix and worked as expected )

Again, thanks for this amazing job!