### PR TITLE
Bump elliptic 

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"browserify-rsa": "^4.1.0",
 		"create-hash": "^1.2.0",
 		"create-hmac": "^1.1.7",
-		"elliptic": "^6.5.5",
+		"elliptic": "^6.5.7",
 		"hash-base": "~3.0",
 		"inherits": "^2.0.4",
 		"parse-asn1": "^5.1.7",


### PR DESCRIPTION
Dependabots are being raised for elliptic
https://github.com/indutny/elliptic/issues/319

Due to this issue:
Improper Verification of Cryptographic Signature
https://security.snyk.io/vuln/SNYK-JS-ELLIPTIC-7577916

Which was fixed in ellipsis@6.5.7
https://github.com/indutny/elliptic/pull/317
