### PR TITLE
add package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
 		"algos.js"
 	],
 	"main": "index.js",
+	"exports": {
+		".": "./index.js",
+		"./algos": "./algos.js"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/crypto-browserify/browserify-sign.git"


### PR DESCRIPTION
Adding `exports` field in `package.json` to make it easier for modern bundlers to properly bundle this package.