### PR TITLE
[Fix] sign/verify generic SHA algorithms with RSA keys

### DIFF
--- a/browser/algorithms.json
+++ b/browser/algorithms.json
@@ -50,24 +50,24 @@
     "id": ""
   },
   "sha256": {
-    "sign": "ecdsa",
+    "sign": "ecdsa/rsa",
     "hash": "sha256",
-    "id": ""
+    "id": "3031300d060960864801650304020105000420"
   },
   "sha224": {
-    "sign": "ecdsa",
+    "sign": "ecdsa/rsa",
     "hash": "sha224",
-    "id": ""
+    "id": "302d300d06096086480165030402040500041c"
   },
   "sha384": {
-    "sign": "ecdsa",
+    "sign": "ecdsa/rsa",
     "hash": "sha384",
-    "id": ""
+    "id": "3041300d060960864801650304020205000430"
   },
   "sha512": {
-    "sign": "ecdsa",
+    "sign": "ecdsa/rsa",
     "hash": "sha512",
-    "id": ""
+    "id": "3051300d060960864801650304020305000440"
   },
   "DSA-SHA": {
     "sign": "dsa",

--- a/test/index.js
+++ b/test/index.js
@@ -72,6 +72,29 @@ test('valid RSA fixtures', function (t) {
   });
 });
 
+test('generic SHA algorithms sign RSA keys like node', function (t) {
+  var f = fixtures.valid.rsa[0];
+  var message = Buffer.from(f.message);
+  var priv = Buffer.from(f['private'], 'base64');
+  var pub = Buffer.from(f['public'], 'base64');
+
+  ['sha224', 'sha256', 'sha384', 'sha512'].forEach(function (scheme) {
+    t.test('algorithm: ' + scheme, { skip: !(nCrypto.getHashes().indexOf(scheme) >= 0) }, function (st) {
+      var bSig = bCrypto.createSign(scheme).update(message).sign(priv);
+      var nSig = nCrypto.createSign(scheme).update(message).sign(priv);
+
+      st.equals(bSig.length, nSig.length, 'correct length');
+      st.equals(bSig.toString('hex'), nSig.toString('hex'), 'equal sigs');
+      st.ok(nCrypto.createVerify(scheme).update(message).verify(pub, bSig), 'node validates browser sig');
+      st.ok(bCrypto.createVerify(scheme).update(message).verify(pub, nSig), 'browser validates node sig');
+
+      st.end();
+    });
+  });
+
+  t.end();
+});
+
 // node has padding support since 8.0
 // TODO: figure out why node v8.0 - v8.6 is broken
 (semver.satisfies(process.versions.node, '>= 8.6') ? test : test.skip)('padding option', function (t) {


### PR DESCRIPTION
## Summary
- allow generic SHA algorithms to sign and verify RSA keys by using the same PKCS#1 DigestInfo tags as the RSA-named aliases
- add Node parity coverage for sha224, sha256, sha384, and sha512 with RSA keys

Fixes #84

## Verification
- npm_config_cache=/tmp/browserify-sign-84-npm-cache npx tape test/index.js (red before fix: wrong private key type; green after fix: 629/629)
- npm_config_cache=/tmp/browserify-sign-84-npm-cache npm run lint (exit 0; existing warnings only)
- npm_config_cache=/tmp/browserify-sign-84-npm-cache npm run tests-only (629/629, 100% coverage)
- git diff --check
- npm_config_cache=/tmp/browserify-sign-84-npm-cache npm test (exit 0; audit reports existing low elliptic advisory with no fix available)